### PR TITLE
Added config parameter to enable telem Half Duplex on MotolabF4

### DIFF
--- a/src/main/target/MOTOLABF4/config.c
+++ b/src/main/target/MOTOLABF4/config.c
@@ -29,6 +29,6 @@
 void targetConfiguration(void)
 {
     sdcardConfigMutable()->useDma = true;
-    telemetryConfigMutable()->halfDuplex = 0;
+    telemetryConfigMutable()->halfDuplex = 1;
 }
 #endif


### PR DESCRIPTION
Added config parameter to Motolab Tempest F4 to set Telemetry Half Duplex as ON by default.

Previous values were causing quad not to arm as per [this issue](https://github.com/ButterFlight/butterflight/issues/20)