### PR TITLE
default filter biquad

### DIFF
--- a/src/main/target/HELIOSPRING/config.c
+++ b/src/main/target/HELIOSPRING/config.c
@@ -83,7 +83,7 @@ void targetConfiguration(void) {
         // pidProfile->dterm_lpf_hz = 0;    
         // pidProfile->dterm_notch_hz = 0;
         // pidProfile->dterm_notch_cutoff = 0;
-        pidProfile->dterm_filter_type = FILTER_PT1;
+        pidProfile->dterm_filter_type = FILTER_BIQUAD;
         pidProfile->dterm_filter_style = KD_FILTER_NOSP;
         pidProfile->dterm_lpf_hz = 60;
     }


### PR DESCRIPTION
defaulting to biquad due to the difference in filtering quality
PT1:
![image](https://user-images.githubusercontent.com/1736223/37048211-6cceca7e-212a-11e8-9fd3-3243c129e20b.png)
BIQUAD:
![image](https://user-images.githubusercontent.com/1736223/37048240-7bf1e3a6-212a-11e8-94c0-39a20f166830.png)
