### PR TITLE
Mach2 support for vtx_akk_hack

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -22,7 +22,7 @@
 #define FC_FIRMWARE_NAME            "ButterFlight"
 #define FC_VERSION_MAJOR            3  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            4  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      2  // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -22,7 +22,7 @@
 #define FC_FIRMWARE_NAME            "ButterFlight"
 #define FC_VERSION_MAJOR            3  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            4  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      2  // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 


### PR DESCRIPTION
Different cmd queue for standard Smart Audio and akk / Mach 2 implementation. 

The used queue is depending on the vtx_akk_hack CLI setting.

