### PR TITLE
RDQ Mach2 fixed queue-full detection and port options

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -524,7 +524,7 @@ static bool saQueueEmpty(void)
 
 static bool saQueueFull(void)
 {
-    return ((sa_qhead + 1) % SA_QSIZE) == sa_qtail;
+	return ((sa_qhead + 1) % vtxSettingsConfig()->akkStyleEndFrame ? SA_AKK_MACH2_QSIZE : SA_QSIZE) == sa_qtail;
 }
 
 static void saQueueCmdInner(saCmdQueue_t *queue, uint8_t qSize, uint8_t *buf, int len)
@@ -700,8 +700,7 @@ bool vtxSmartAudioInit(void)
 
     serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
-	    portOptions_e portOptions = vtxSettingsConfig()->akkStyleEndFrame ? SERIAL_STOPBITS_1 : SERIAL_STOPBITS_2;
-	    portOptions = portOptions | SERIAL_BIDIR_NOPULL;
+	    portOptions_e portOptions = vtxSettingsConfig()->akkStyleEndFrame ? SERIAL_STOPBITS_1 : SERIAL_STOPBITS_2 | SERIAL_BIDIR_NOPULL;
 
 #if defined(USE_VTX_COMMON)
         portOptions = portOptions | (vtxConfig()->halfDuplex ? SERIAL_BIDIR | SERIAL_BIDIR_PP : SERIAL_UNIDIR);


### PR DESCRIPTION
Smart Audio queue full detection now also depends on the vtx_akk_hack cli option to return the truth about the queue being full.

Port options reverted to the pre-broken initial value in case the vtx_akk_hack is enabled.

