### PR TITLE
Added target for Airbot Omnibus F4 Nano v2.5

### DIFF
--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -26,7 +26,7 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 
-#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO)
+#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO) || defined(OBF4NANOBB)
     DEF_TIM(TIM10, CH1, PB8,  TIM_USE_PWM | TIM_USE_PPM,   0, 0), // PPM
     DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_PWM,                 0, 0), // S2_IN
 #else
@@ -44,7 +44,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               0, 1), // S3_OUT D1_ST6
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               0, 0), // S4_OUT D1_ST1
 
-#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO)
+#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO) || defined(OBF4NANOBB)
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               0, 0), // S5_OUT
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,                 0, 0), // LED strip for F4 V2 / F4-Pro-0X and later (RCD_CS for F4)
 #else

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -19,6 +19,8 @@
 
 #if defined(OMNIBUSF4SD)
 #define TARGET_BOARD_IDENTIFIER "OBSD"
+#elif defined(OBF4NANOBB)
+#define TARGET_BOARD_IDENTIFIER "NANO"
 #elif defined(LUXF4OSD)
 #define TARGET_BOARD_IDENTIFIER "LUX4"
 #elif defined(DYSF4PRO)
@@ -40,6 +42,8 @@
 #define USBD_PRODUCT_STRING "XRACERF4"
 #elif defined(EXUAVF4PRO)
 #define USBD_PRODUCT_STRING "ExuavF4Pro"
+#elif defined(OBF4NANOBB)
+#define USBD_PRODUCT_STRING "OBF4Nano"
 #else
 #define USBD_PRODUCT_STRING "OmnibusF4"
 #endif
@@ -62,7 +66,7 @@
 // Users of these timers/pads must un-map the inverter assignment explicitly.
 #define INVERTER_PIN_UART6      PC8 // Omnibus F4 V3 and later
 #define INVERTER_PIN_UART3      PC9 // Omnibus F4 Pro Corners
-#elif defined(EXUAVF4PRO)
+#elif defined(EXUAVF4PRO) || defined (OBF4NANOBB)
 #define INVERTER_PIN_UART6      PC8
 #else
 #define INVERTER_PIN_UART1      PC0 // PC0 used as inverter select GPIO XXX this is not used --- remove it at the next major release
@@ -82,7 +86,7 @@
 #define MPU_INT_EXTI            PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
-#if defined(OMNIBUSF4SD)
+#if defined(OMNIBUSF4SD) || defined(OBF4NANOBB)
 #define GYRO_MPU6000_ALIGN       CW270_DEG
 #define ACC_MPU6000_ALIGN        CW270_DEG
 #elif defined(XRACERF4) || defined(EXUAVF4PRO)
@@ -113,7 +117,7 @@
 //#define MAG_NAZA_ALIGN CW180_DEG_FLIP  // Ditto
 
 #define USE_BARO
-#if defined(OMNIBUSF4SD)
+#if defined(OMNIBUSF4SD) || defined(OBF4NANOBB)
 #define USE_BARO_SPI_BMP280
 #define BMP280_SPI_INSTANCE     SPI3
 #define BMP280_CS_PIN           PB3 // v1
@@ -123,7 +127,7 @@
 #define USE_BARO_MS5611
 #define BARO_I2C_INSTANCE       (I2CDEV_2)
 
-#if defined(OMNIBUSF4SD)
+#if defined(OMNIBUSF4SD) || defined(OBF4NANOBB)
 #define DEFAULT_BARO_SPI_BMP280
 #else
 #define DEFAULT_BARO_BMP280
@@ -149,7 +153,7 @@
 
 #define SDCARD_DMA_CHANNEL_TX                   DMA1_Stream4
 #define SDCARD_DMA_CHANNEL                      0
-#elif defined(LUXF4OSD)
+#elif defined(LUXF4OSD) || defined(OBF4NANOBB)
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define M25P16_CS_PIN           PB12
 #define M25P16_SPI_INSTANCE     SPI2
@@ -203,7 +207,7 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_1
 
-#if defined(OMNIBUSF4SD) || defined(LUXF4OSD)
+#if defined(OMNIBUSF4SD) || defined(LUXF4OSD) || defined(OBF4NANOBB)
 #define USE_SPI_DEVICE_2
 #define SPI2_NSS_PIN            PB12
 #define SPI2_SCK_PIN            PB13
@@ -266,7 +270,7 @@
 #define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
 #define TARGET_IO_PORTD BIT(2)
 
-#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO)
+#if defined(OMNIBUSF4SD) || defined(EXUAVF4PRO) || defined(OBF4NANOBB)
 #define USABLE_TIMER_CHANNEL_COUNT 15
 #define USED_TIMERS ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(10) | TIM_N(12) | TIM_N(8) | TIM_N(9))
 #else


### PR DESCRIPTION
Added target for Airbot Omnibus F4 Nano v2.5 to properly support LED pad, barometer and blackbox.