### PR TITLE
Implement vtx_akk_hack cli command as a switchable feature

### DIFF
--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -51,7 +51,7 @@ typedef enum {
     FEATURE_ESC_SENSOR = 1 << 27,
     FEATURE_ANTI_GRAVITY = 1 << 28,
     FEATURE_DYNAMIC_FILTER = 1 << 29,
-	FEATURE_LEGACY_SA_SUPPORT = 1 << 30,
+    FEATURE_LEGACY_SA_SUPPORT = 1 << 30,
 } features_e;
 
 typedef struct featureConfig_s {

--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -51,6 +51,7 @@ typedef enum {
     FEATURE_ESC_SENSOR = 1 << 27,
     FEATURE_ANTI_GRAVITY = 1 << 28,
     FEATURE_DYNAMIC_FILTER = 1 << 29,
+	FEATURE_LEGACY_SA_SUPPORT = 1 << 30,
 } features_e;
 
 typedef struct featureConfig_s {

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -184,7 +184,7 @@ static const char * const featureNames[] = {
     "RANGEFINDER", "TELEMETRY", "", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "OSD",
     "", "CHANNEL_FORWARDING", "TRANSPONDER", "AIRMODE",
-    "", "", "RX_SPI", "SOFTSPI", "ESC_SENSOR", "ANTI_GRAVITY", "DYNAMIC_FILTER", NULL
+    "", "", "RX_SPI", "SOFTSPI", "ESC_SENSOR", "ANTI_GRAVITY", "DYNAMIC_FILTER", "LEGACY_SA_SUPPORT", NULL
 };
 
 // sync this with rxFailsafeChannelMode_e

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -850,7 +850,6 @@ const clivalue_t valueTable[] = {
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHANNEL, VTX_SETTINGS_MAX_CHANNEL }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_POWER_COUNT-1 }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
     { "vtx_low_power_disarm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, lowPowerDisarm) },
-    { "vtx_akk_hack",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, akkStyleEndFrame) },
 #ifdef VTX_SETTINGS_FREQCMD
     { "vtx_freq",                   VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, freq) },
     { "vtx_pit_mode_freq",          VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, pitModeFreq) },

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -52,7 +52,6 @@ PG_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig,
     .freq = VTX_SETTINGS_DEFAULT_FREQ,
     .pitModeFreq = VTX_SETTINGS_DEFAULT_PITMODE_FREQ,
     .lowPowerDisarm = VTX_SETTINGS_DEFAULT_LOW_POWER_DISARM,
-    .akkStyleEndFrame = VTX_SETTINGS_DEFAULT_AKK_HACK,
 );
 
 typedef enum {

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -30,7 +30,6 @@ typedef struct vtxSettingsConfig_s {
     uint16_t freq;          // sets freq in MHz if band=0
     uint16_t pitModeFreq;   // sets out-of-range pitmode frequency
     uint8_t lowPowerDisarm; // min power while disarmed
-    uint8_t akkStyleEndFrame; // Fix for older AKK with 0x00 end frame
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -99,6 +99,7 @@ void saSetPowerByIndex(uint8_t index);
 void saSetFreq(uint16_t freq);
 void saSetPitFreq(uint16_t freq);
 bool vtxSmartAudioInit(void);
+bool isLegacySmartAudioEnabled(void);
 
 #ifdef SMARTAUDIO_DPRINTF
 #ifdef OMNIBUSF4


### PR DESCRIPTION
- Refactored the current CLI based implementation of vtx_akk_hack into a new feature named: "LEGACY_SA_SUPPORT"

- Re-added the tailing byte in send frame as a possible fix for the "standard" implementation of Smart Audio, due to user reporting that turning the hack off for Unify and other "standard" SA VTX-es will result in an incorrect setting save issue (settings are only saved after unplugging and re-plugging the battery)

- This PR should be accepted with the [relevant Butterflight-Configurator PR](https://github.com/ButterFlight/butterflight-configurator/pull/17) that adds the "LEGACY_SA_SUPPORT" feature to the configuration tab

- Incrementing the MSP protocol minor version to 39 and the EEPROM version is required before release

