### PR TITLE
adding stick arming as an option and setting it to false by default

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -64,9 +64,6 @@
 
 static pidProfile_t *pidProfile;
 
-// true if arming is done via the sticks (as opposed to a switch)
-static bool isUsingSticksToArm = true;
-
 float rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
 
 PG_REGISTER_WITH_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
@@ -76,14 +73,15 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .yaw_deadband = 0,
     .alt_hold_deadband = 40,
     .alt_hold_fast_change = 1,
-    .yaw_control_reversed = false,
+    .yaw_control_reversed = false
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 1);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,  // TODO - Cleanup retarded arm support
-    .auto_disarm_delay = 5
+    .auto_disarm_delay = 5,
+    .isUsingSticksForArming = false
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
@@ -97,7 +95,7 @@ PG_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig,
 
 bool isUsingSticksForArming(void)
 {
-    return isUsingSticksToArm;
+    return armingConfig()->isUsingSticksForArming;
 }
 
 bool areSticksInApModePosition(uint16_t ap_mode)
@@ -167,7 +165,7 @@ void processRcStickPositions()
     rcSticks = stTmp;
 
     // perform actions
-    if (!isUsingSticksToArm) {
+    if (!isUsingSticksForArming()) {
         if (IS_RC_MODE_ACTIVE(BOXARM)) {
             rcDisarmTicks = 0;
             // Arming via ARM BOX
@@ -381,6 +379,4 @@ int32_t getRcStickDeflection(int32_t axis, uint16_t midrc) {
 void useRcControlsConfig(pidProfile_t *pidProfileToUse)
 {
     pidProfile = pidProfileToUse;
-
-    isUsingSticksToArm = !isModeActivationConditionPresent(BOXARM);
 }

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -102,6 +102,7 @@ PG_DECLARE(flight3DConfig_t, flight3DConfig);
 typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // allow disarm/arm on throttle down + roll left/right
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
+    bool isUsingSticksForArming;            // allow using sticks position to arm
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -619,6 +619,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { "gyro_cal_on_first_arm",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
+    { "use_stick_arming",           VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, isUsingSticksForArming) },    
 
 
 // PG_GPS_CONFIG


### PR DESCRIPTION
turning off using sticks to arm by default and making it a CLI option
```
set use_stick_arming = OFF
set use_stick_arming = ON
```

The reason for this is that arming with sticks is actually very dangerous. Some people may prefer to do it but we should disable it by default.