### PR TITLE
constraining step count to match the constraint of 16KHZ

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -222,7 +222,7 @@ void processRcCommand(void)
                     rxRefreshRate = rxGetRefreshRate();
             }
 
-            rcInterpolationStepCount = rxRefreshRate / targetPidLooptime;
+            rcInterpolationStepCount = rxRefreshRate / constrainf(targetPidLooptime, 62.5f, 5000.0f);
             inverseRcInt = 1.0f / (float)rcInterpolationStepCount;
 
             for (int channel = ROLL; channel < interpolationChannels; channel++) {


### PR DESCRIPTION
This constrains the step count to match the minumum target loop time to the steps work properly.