### PR TITLE
Increase MSP protocol version to 1.40.0

### DIFF
--- a/src/main/interface/msp_protocol.h
+++ b/src/main/interface/msp_protocol.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1  // increment when major changes are made
-#define API_VERSION_MINOR                   39 // increment after a release, to set the version for all changes to go into the following release (if no changes to MSP are made between the releases, this can be reverted before the release)
+#define API_VERSION_MINOR                   40 // increment after a release, to set the version for all changes to go into the following release (if no changes to MSP are made between the releases, this can be reverted before the release)
 
 #define API_VERSION_LENGTH                  2
 


### PR DESCRIPTION
With the addition of gyro_stage_2_filter_type to MSP, the protocol version must be bumped.

