### PR TITLE
Add gps heading to imumahony filter (fixed for quaternion update)

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -35,6 +35,7 @@
 #define DECIDEGREES_TO_DEGREES(angle) (angle / 10)
 #define DECIDEGREES_TO_RADIANS(angle) ((angle / 10.0f) * 0.0174532925f)
 #define DEGREES_TO_RADIANS(angle) ((angle) * 0.0174532925f)
+#define RADIANS_TO_DECIDEGREES(angle) (((angle) * 10.0f) / RAD)
 
 #define CM_S_TO_KM_H(centimetersPerSecond) (centimetersPerSecond * 36 / 1000)
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -77,6 +77,7 @@ acc_t acc;
 mag_t mag;
 
 gpsSolutionData_t gpsSol;
+uint16_t GPS_distanceToHome = 0;
 
 uint8_t debugMode;
 int16_t debug[DEBUG16_VALUE_COUNT];


### PR DESCRIPTION
Pass gps heading data into IMU mahony to gradually correct over time.  This should allow the home arrow to work without having to plug in facing north.
