### PR TITLE
updating default pids for yaw

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -91,7 +91,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pid = {
             [PID_ROLL] =  { 40, 40, 20 },
             [PID_PITCH] = { 58, 50, 22 },
-            [PID_YAW] =   { 70, 45, 8 },
+            [PID_YAW] =   { 55, 45, 5 },
             [PID_ALT] =   { 50, 0, 0 },
             [PID_POS] =   { 15, 0, 0 },     // POSHOLD_P * 100, POSHOLD_I * 100,
             [PID_POSR] =  { 34, 14, 53 },   // POSHOLD_RATE_P * 10, POSHOLD_RATE_I * 100, POSHOLD_RATE_D * 1000,

--- a/src/main/target/HELIOSPRING/config.c
+++ b/src/main/target/HELIOSPRING/config.c
@@ -54,6 +54,7 @@ void targetConfiguration(void) {
         pidProfile->pid[PID_ROLL].I = 50;
         pidProfile->pid[PID_YAW].P = 45;	
         pidProfile->pid[PID_YAW].I = 50;
+        pidProfile->pid[PID_YAW].D = 8;
 
         /* Setpoints */
         // should't need to set these since they don't get init in gyro.c with USE_GYRO_IMUF


### PR DESCRIPTION
defaults Yaw kD to 5 and kP to 55 default.

defaults Helio target to 8.


This also properly applies D filtering to yaw when it was not being properly applied.
also refactored pid filter initialization to save ~1.5k in flash storage.