### PR TITLE
Butterflight 3.5.1 RC HEADFREE fix

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -85,7 +85,7 @@ static float smallAngleCosZ = 0;
 static imuRuntimeConfig_t imuRuntimeConfig;
 
 // quaternion of sensor frame relative to earth frame
-STATIC_UNIT_TESTED quaternion qAttitude = QUATERNION_INITIALIZE;
+quaternion qAttitude = QUATERNION_INITIALIZE;
 STATIC_UNIT_TESTED quaternionProducts qpAttitude = QUATERNION_PRODUCTS_INITIALIZE;
 // headfree quaternions
 quaternion qHeadfree = QUATERNION_INITIALIZE;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -45,6 +45,7 @@ typedef union {
 
 extern attitudeEulerAngles_t attitude;
 extern quaternion qHeadfree;
+extern quaternion qAttitude;
 
 typedef struct accDeadband_s {
     uint8_t xy;                 // set the acc deadband for xy-Axis


### PR DESCRIPTION
on corner flips in HEADFREE mode flip end position is YAW  45° rotated from default
flips in ACRO mode need to be handled separate from those in  HORIZON modes.

