### PR TITLE
Set NVIC_PRIO_MPU_INT_EXTI priority with condition

### DIFF
--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -8,7 +8,11 @@
 #define NVIC_PRIO_BARO_EXTI                NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_SONAR_EXTI               NVIC_BUILD_PRIORITY(2, 0)  // maybe increase slightly
 #define NVIC_PRIO_TRANSPONDER_DMA          NVIC_BUILD_PRIORITY(3, 0)
+#ifdef USE_DMA_SPI_DEVICE
 #define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0x00, 0x02)
+#else
+#define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
+#endif //USE_DMA_SPI_DEVICE
 #define NVIC_PRIO_MAG_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_WS2811_DMA               NVIC_BUILD_PRIORITY(1, 2)  // TODO - is there some reason to use high priority? (or to use DMA IRQ at all?)
 #define NVIC_PRIO_SERIALUART_TXDMA         NVIC_BUILD_PRIORITY(1, 1)  // Highest of all SERIALUARTx_TXDMA


### PR DESCRIPTION
Added USE_DMA_SPI_DEVICE condition for NVIC_MPU_INT_EXTI priority value (changed in 3.5.0) and reverted value to the 3.4.2 value otherwise

