### PR TITLE
"Buttered Pids" are equivalent to "Classic Pids" in the absence of Setpoint Weight and Dterm Notch

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -101,7 +101,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 2);
 
-void resetPidProfile(pidProfile_t *pidProfile)
+STATIC_UNIT_TESTED void resetPidProfile(pidProfile_t *pidProfile)
 {
     RESET_CONFIG(pidProfile_t, pidProfile,
         .pid = {
@@ -226,7 +226,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
             dtermFilterNotch[axis] = &biquadFilterNotch[axis];
             biquadFilterInit(dtermFilterNotch[axis], dTermNotchHz, targetPidLooptime, notchQ, FILTER_NOTCH);
-        }    
+        }
     } else {
         dtermNotchFilterApplyFn = nullFilterApply;
     }
@@ -279,8 +279,84 @@ static FAST_RAM float crashSetpointThreshold;
 static FAST_RAM float crashLimitYaw;
 static FAST_RAM float itermLimit;
 
-float butteredPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint);
-float classicPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint);
+static FAST_RAM float previousRateError[3];
+static FAST_RAM timeUs_t crashDetectedAtUs;
+static FAST_RAM timeUs_t previousTimeUs;
+
+// Butterflight pid controlelr which uses measurement instead of error rate to calculate D
+STATIC_UNIT_TESTED float butteredPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint)
+{
+    (void)(pidProfile);
+    (void)(currentPidSetpoint);
+    // -----calculate P component
+    axisPID_P[axis] = (Kp[axis] * errorRate) * getThrottlePIDAttenuation();
+
+    // -----calculate I component
+    float iterm = constrainf(axisPID_I[axis] + (Ki[axis] * errorRate) * dynCi, -itermLimit, itermLimit);
+    if (!mixerIsOutputSaturated(axis, errorRate) || ABS(iterm) < ABS(axisPID_I[axis])) {
+        // Only increase ITerm if output is not saturated
+        axisPID_I[axis] = iterm;
+    }
+    // -----calculate D component
+    // use measurement and apply filters. mmmm gimme that butter.
+    float dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], -((gyro.gyroADCf[axis] - previousRateError[axis]) * iDT));
+    previousRateError[axis] = gyro.gyroADCf[axis];
+    axisPID_D[axis] = Kd[axis] * (dDelta) * getThrottlePIDAttenuation();
+    axisPIDSum[axis] = axisPID_P[axis] + axisPID_I[axis] + axisPID_D[axis];
+    return dDelta;
+}
+
+// Betaflight pid controller, which will be maintained in the future with additional features specialised for current (mini) multirotor usage.
+// Based on 2DOF reference design (matlab)
+
+STATIC_UNIT_TESTED float classicPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint)
+{
+    // --------low-level gyro-based PID based on 2DOF PID controller. ----------
+    // 2-DOF PID controller with optional filter on derivative term.
+    // b = 1 and only c (dtermSetpointWeight) can be tuned (amount derivative on measurement or error).
+
+    // -----calculate P component and add Dynamic Part based on stick input
+    axisPID_P[axis] = Kp[axis] * errorRate * getThrottlePIDAttenuation();
+
+    // -----calculate I component
+    float ITermNew = constrainf(axisPID_I[axis] + Ki[axis] * errorRate * dynCi, -itermLimit, itermLimit);
+    if (!mixerIsOutputSaturated(axis, errorRate) || ABS(ITermNew) < ABS(axisPID_I[axis])) {
+        // Only increase ITerm if output is not saturated
+        axisPID_I[axis] = ITermNew;
+    }
+
+    // -----calculate D component
+    // apply filters
+    float gyroRateFiltered = dtermNotchFilterApplyFn(dtermFilterNotch[axis], gyro.gyroADCf[axis]);
+    if (pidProfile->dterm_filter_style == KD_FILTER_CLASSIC)
+    {
+        gyroRateFiltered = dtermLpfApplyFn(dtermFilterLpf[axis], gyroRateFiltered);
+    }
+
+    float setpointT = flightModeFlags ? 0.0f : dtermSetpointWeight * MIN(getRcDeflectionAbs(axis) * relaxFactor, 1.0f);
+    float ornD = setpointT * currentPidSetpoint - gyroRateFiltered;
+    float dDelta = 0.0f;
+    switch (pidProfile->dterm_filter_style) {
+        case KD_FILTER_SP:
+            //filter Kd properly along with sp
+            dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], (ornD - previousRateError[axis]) * iDT );
+            break;
+        case KD_FILTER_NOSP:
+            ornD = setpointT * getSetpointRate(axis) - gyroRateFiltered;    // cr - y
+            dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], (ornD - previousRateError[axis]) * iDT );
+            //filter Kd properly, no sp
+            break;
+        case KD_FILTER_CLASSIC:
+        default:
+            dDelta = (ornD - previousRateError[axis]) * iDT;
+            break;
+    }
+    previousRateError[axis] = ornD;
+    axisPID_D[axis] = Kd[axis] * dDelta * getThrottlePIDAttenuation();
+    axisPIDSum[axis] = axisPID_P[axis] + axisPID_I[axis] + axisPID_D[axis];
+    return dDelta;
+}
+
 
 void pidInitConfig(const pidProfile_t *pidProfile)
 {
@@ -420,91 +496,11 @@ static float accelerationLimit(int axis, float currentPidSetpoint)
     return currentPidSetpoint;
 }
 
-static FAST_RAM float previousRateError[3];
-static FAST_RAM timeUs_t crashDetectedAtUs;
-static FAST_RAM timeUs_t previousTimeUs;
-
-// Butterflight pid controlelr which uses measurement instead of error rate to calculate D
-float butteredPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint) 
-{
-    (void)(pidProfile);
-    (void)(currentPidSetpoint);
-    // -----calculate P component
-    axisPID_P[axis] = (Kp[axis] * errorRate) * getThrottlePIDAttenuation();
-
-    // -----calculate I component
-    float iterm = constrainf(axisPID_I[axis] + (Ki[axis] * errorRate) * dynCi, -itermLimit, itermLimit);
-    if (!mixerIsOutputSaturated(axis, errorRate) || ABS(iterm) < ABS(axisPID_I[axis])) {
-        // Only increase ITerm if output is not saturated
-        axisPID_I[axis] = iterm;
-    }
-
-    // -----calculate D component
-    // use measurement and apply filters. mmmm gimme that butter.      
-    float dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], -((gyro.gyroADCf[axis] - previousRateError[axis]) * iDT));
-    previousRateError[axis] = gyro.gyroADCf[axis];
-    axisPID_D[axis] = Kd[axis] * (dDelta) * getThrottlePIDAttenuation();
-    axisPIDSum[axis] = axisPID_P[axis] + axisPID_I[axis] + axisPID_D[axis];
-    return dDelta;
-}
-
-// Betaflight pid controller, which will be maintained in the future with additional features specialised for current (mini) multirotor usage.
-// Based on 2DOF reference design (matlab)
-
-float classicPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint) 
-{
-    // --------low-level gyro-based PID based on 2DOF PID controller. ----------
-    // 2-DOF PID controller with optional filter on derivative term.
-    // b = 1 and only c (dtermSetpointWeight) can be tuned (amount derivative on measurement or error).
-
-    // -----calculate P component and add Dynamic Part based on stick input
-    axisPID_P[axis] = Kp[axis] * errorRate * getThrottlePIDAttenuation();
-
-    // -----calculate I component
-    float ITermNew = constrainf(axisPID_I[axis] + Ki[axis] * errorRate * dynCi, -itermLimit, itermLimit);
-    if (!mixerIsOutputSaturated(axis, errorRate) || ABS(ITermNew) < ABS(axisPID_I[axis])) {
-        // Only increase ITerm if output is not saturated
-        axisPID_I[axis] = ITermNew;
-    }
-
-    // -----calculate D component
-    // apply filters
-    float gyroRateFiltered = dtermNotchFilterApplyFn(dtermFilterNotch[axis], gyro.gyroADCf[axis]);
-    if (pidProfile->dterm_filter_style == KD_FILTER_CLASSIC)
-    {
-        gyroRateFiltered = dtermLpfApplyFn(dtermFilterLpf[axis], gyroRateFiltered);
-    }
-    
-    float setpointT = flightModeFlags ? 0.0f : dtermSetpointWeight * MIN(getRcDeflectionAbs(axis) * relaxFactor, 1.0f);
-    float ornD = setpointT * currentPidSetpoint - gyroRateFiltered; 
-    float dDelta = 0.0f;
-    switch (pidProfile->dterm_filter_style) {
-        case KD_FILTER_SP:
-            //filter Kd properly along with sp
-            dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], (ornD - previousRateError[axis]) * iDT );
-            break;
-        case KD_FILTER_NOSP:
-            ornD = setpointT * getSetpointRate(axis) - gyroRateFiltered;    // cr - y
-            dDelta = dtermLpfApplyFn(dtermFilterLpf[axis], (ornD - previousRateError[axis]) * iDT );                
-            //filter Kd properly, no sp
-            break;
-        case KD_FILTER_CLASSIC:
-        default:
-            dDelta = (ornD - previousRateError[axis]) * iDT;
-            break;
-    }
-    previousRateError[axis] = ornD;
-    axisPID_D[axis] = Kd[axis] * dDelta * getThrottlePIDAttenuation();
-    axisPIDSum[axis] = axisPID_P[axis] + axisPID_I[axis] + axisPID_D[axis];
-    return dDelta;
-}
-
-
 void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, timeUs_t currentTimeUs)
 {
-    const float deltaT = (currentTimeUs - previousTimeUs) * 0.000001f;   
-    previousTimeUs = currentTimeUs;    
-    
+    const float deltaT = (currentTimeUs - previousTimeUs) * 0.000001f;
+    previousTimeUs = currentTimeUs;
+
     const float motorMixRange = getMotorMixRange();
     // calculate actual deltaT in seconds
     const float iDT = 1.0f/deltaT; //divide once

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -76,6 +76,12 @@ blackbox_unittest_SRC :=  \
 		$(USER_DIR)/common/typeconversion.c \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c
 
+buttered_classic_equiv_unittest_SRC := \
+		$(USER_DIR)/flight/pid.c \
+		$(USER_DIR)/common/filter.c \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/drivers/accgyro/gyro_sync.c
+
 blackbox_encoding_unittest_SRC :=  \
 		$(USER_DIR)/blackbox/blackbox_encoding.c \
 		$(USER_DIR)/common/encoding.c \

--- a/src/test/unit/buttered_classic_equiv_unittest.cc
+++ b/src/test/unit/buttered_classic_equiv_unittest.cc
@@ -1,0 +1,164 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "common/axis.h"
+    #include "common/maths.h"
+    #include "common/filter.h"
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "flight/pid.h"
+    #include "flight/imu.h"
+    #include "drivers/accgyro/accgyro.h"
+    #include "drivers/accgyro/gyro_sync.h"
+    #include "sensors/gyro.h"
+
+    gyro_t gyro;
+    pidProfile_t pidProfileTest;
+    pidProfile_t *pidProfile = &pidProfileTest;
+
+    void resetPidProfile(pidProfile_t *pidProfile);
+    float butteredPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint);
+    float classicPids(const pidProfile_t *pidProfile, int axis, float errorRate, float dynCi, float iDT, float currentPidSetpoint);
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+gyroDev_t gyroDev;
+
+bool computeAndCompareDerivatives(uint16_t notchCutoff, uint16_t lpfCutoff, uint8_t filterStyle, uint8_t setpointWeight)
+{
+    // Calculate derivatives on separate axes so filter and derivative states are isolated
+    const int axisButtered = FD_ROLL;
+    const int axisClassic = FD_PITCH;
+    const float gyroRate = 125.0f; // 8k
+    const float errorRate = 1.0f;
+    const float dynCi = 1.0f;
+    const float dT = gyroRate * 0.000001f;
+    const float iDT = 1.0f / dT;
+    const float currentPidSetpoint = 1.0f;
+    float deltaButtered = 0;
+    float deltaClassic = 0;
+    float randVal = 0;
+    bool deltaMatch = false;
+
+    gyro.targetLooptime = gyroRate;
+    pidConfigMutable()->pid_process_denom = 1;
+    resetPidProfile(pidProfile);
+
+    srand(1);  // idempotence :)
+
+    pidProfile->dtermSetpointWeight = setpointWeight;
+    pidProfile->dterm_filter_style = filterStyle;
+    pidProfile->dterm_notch_hz = notchCutoff;
+    pidProfile->dterm_lpf_hz = lpfCutoff;
+    pidInit(pidProfile);
+
+    for (unsigned int i=0; i<1000000; ++i) {
+        randVal = ((float)rand() / ((float)RAND_MAX+1) * 2000);
+        gyro.gyroADCf[axisButtered] = randVal;
+        gyro.gyroADCf[axisClassic] = randVal;
+        deltaButtered = butteredPids(pidProfile, axisButtered, errorRate, dynCi, iDT, currentPidSetpoint);
+        deltaClassic = classicPids(pidProfile, axisClassic, errorRate, dynCi, iDT, currentPidSetpoint);
+        deltaMatch = (deltaButtered == deltaClassic);
+        if (!deltaMatch) {
+	    // break upon first failure and fast return
+            break;
+        }
+    }
+
+    return deltaMatch;
+
+}
+
+TEST(ButteredPidsHypeTest, NoSetpointWeightAndNotch_SP)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_SP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_TRUE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, NoSetpointWeightAndNotch_NOSP)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_NOSP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_TRUE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, NoSetpointWeightAndNotch_SP_LPF)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 160;
+    const uint8_t filterStyle = KD_FILTER_SP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_TRUE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, NoSetpointWeightAndNotch_NOSP_LPF)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 160;
+    const uint8_t filterStyle = KD_FILTER_NOSP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_TRUE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, FailOnSetpointWeight_SP)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_SP;
+    const uint8_t setpointWeight = 1;
+    EXPECT_FALSE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, FailOnSetpointWeight_NOSP)
+{
+    const uint16_t notchCutoff = 0;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_NOSP;
+    const uint8_t setpointWeight = 1;
+    EXPECT_FALSE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, FailOnNotch_SP)
+{
+    const uint16_t notchCutoff = 120;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_SP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_FALSE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+TEST(ButteredPidsHypeTest, FailOnNotch_NOSP)
+{
+    const uint16_t notchCutoff = 120;
+    const uint16_t lpfCutoff = 0;
+    const uint8_t filterStyle = KD_FILTER_NOSP;
+    const uint8_t setpointWeight = 0;
+    EXPECT_FALSE(computeAndCompareDerivatives(notchCutoff, lpfCutoff, filterStyle, setpointWeight));
+}
+
+extern "C" { //stubs
+    attitudeEulerAngles_t attitude;
+    uint16_t flightModeFlags = 0;
+    uint16_t armingFlags = 0;
+    int16_t GPS_angle[2] = { 0, 0 };
+    float getThrottlePIDAttenuation(void) { return 0; }
+    bool mixerIsOutputSaturated(int, float) { return false; }
+    float getRcDeflectionAbs(int) { return 10.0f; }
+    float getRcDeflection(int) { return 0; }
+    float getSetpointRate(int) { return 0; }
+    float getMotorMixRange(int) { return 0; }
+    void systemBeep(bool) { return; }
+    bool sensors(uint32_t) { return false; }
+    bool gyroOverflowDetected(void) { return false; }
+}


### PR DESCRIPTION
This unit test has been built to prove that "buttered pids" are no different than "classic pids" when the dterm notch is disabled setpoint weight is set to zero.

The additional code and configuration is superfluous bloat and adds no additional value.  If you feel differently, please write a test that proves otherwise.

```[==========] Running 8 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 8 tests from ButteredPidsHypeTest
[ RUN      ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_SP
[       OK ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_SP (75 ms)
[ RUN      ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_NOSP
[       OK ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_NOSP (89 ms)
[ RUN      ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_SP_LPF
[       OK ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_SP_LPF (90 ms)
[ RUN      ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_NOSP_LPF
[       OK ] ButteredPidsHypeTest.NoSetpointWeightAndNotch_NOSP_LPF (97 ms)
[ RUN      ] ButteredPidsHypeTest.FailOnSetpointWeight_SP
[       OK ] ButteredPidsHypeTest.FailOnSetpointWeight_SP (0 ms)
[ RUN      ] ButteredPidsHypeTest.FailOnSetpointWeight_NOSP
[       OK ] ButteredPidsHypeTest.FailOnSetpointWeight_NOSP (0 ms)
[ RUN      ] ButteredPidsHypeTest.FailOnNotch_SP
[       OK ] ButteredPidsHypeTest.FailOnNotch_SP (0 ms)
[ RUN      ] ButteredPidsHypeTest.FailOnNotch_NOSP
[       OK ] ButteredPidsHypeTest.FailOnNotch_NOSP (0 ms)
[----------] 8 tests from ButteredPidsHypeTest (352 ms total)```