### PR TITLE
reduce d-term cutoff frequency below the default gyro cutoff frequency.

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -124,7 +124,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
 
         .pidSumLimit = PIDSUM_LIMIT,
         .yaw_lowpass_hz = 0,
-        .dterm_lowpass_hz = 100,    // filtering ON by default
+        .dterm_lowpass_hz = 60,    // filtering ON by default
         .dterm_lowpass2_hz = 0,    // second Dterm LPF OFF by default
         .dterm_notch_hz = 260,
         .dterm_notch_cutoff = 160,


### PR DESCRIPTION
having the d-term cutoff frequency above the gyro cutoff frequency does not make sense.
this allows an amplification of d-term noise.