### PR TITLE
updating imuf driver and simplifying integration

### DIFF
--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -46,7 +46,9 @@
 #include "drivers/system.h"
 
 
-volatile uint16_t imufCurrentVersion = IMUF_FIRMWARE_VERSION;
+#ifdef USE_GYRO_IMUF9001
+
+volatile uint16_t imufCurrentVersion = IMUF_FIRMWARE_MIN_VERSION;
 volatile uint32_t isImufCalibrating = 0;
 volatile imuFrame_t imufQuat;
 
@@ -180,7 +182,7 @@ int imuf9001Whoami(const gyroDev_t *gyro)
         if (imuf9001SendReceiveCommand(gyro, IMUF_COMMAND_REPORT_INFO, &reply, NULL))
         {
             imufCurrentVersion = (*(imufVersion_t *)&(reply.param1)).firmware;
-            if (imufCurrentVersion < IMUF_FIRMWARE_VERSION) {
+            if (imufCurrentVersion < IMUF_FIRMWARE_MIN_VERSION) {
                 //force update
                 if( (*((__IO uint32_t *)UPT_ADDRESS)) != 0xFFFFFFFF )
                 {
@@ -277,6 +279,31 @@ uint16_t imufGyroAlignment(void)
     }
 }
 
+void setupImufParams(imufCommand_t * data)
+{
+    if (imufCurrentVersion < 107) {
+        //backwards compatibility for Caprica
+        data->param2 = ( (uint16_t)(gyroConfig()->imuf_rate+1) << 16 );
+        data->param3 = ( (uint16_t)gyroConfig()->imuf_pitch_q << 16 )            | (uint16_t)constrain(gyroConfig()->imuf_w, 6, 10);
+        data->param4 = ( (uint16_t)gyroConfig()->imuf_roll_q << 16 )             | (uint16_t)constrain(gyroConfig()->imuf_w, 6, 10);
+        data->param5 = ( (uint16_t)gyroConfig()->imuf_yaw_q << 16 )              | (uint16_t)constrain(gyroConfig()->imuf_w, 6, 10);
+        data->param6 = ( (uint16_t)gyroConfig()->imuf_pitch_lpf_cutoff_hz << 16) | (uint16_t)gyroConfig()->imuf_roll_lpf_cutoff_hz;
+        data->param7 = ( (uint16_t)gyroConfig()->imuf_yaw_lpf_cutoff_hz << 16)   | (uint16_t)0;
+        data->param8 = ( (int16_t)boardAlignment()->rollDegrees << 16 )          | imufGyroAlignment();
+        data->param9 = ( (int16_t)boardAlignment()->yawDegrees << 16 )           | (int16_t)boardAlignment()->pitchDegrees;
+    } else {
+        //Odin contract.
+        data->param2 = ( (uint16_t)(gyroConfig()->imuf_rate+1) << 16)            | (uint16_t)gyroConfig()->imuf_w;
+        data->param3 = ( (uint16_t)gyroConfig()->imuf_roll_q << 16)              | (uint16_t)gyroConfig()->imuf_pitch_q;
+        data->param4 = ( (uint16_t)gyroConfig()->imuf_yaw_q << 16)               | (uint16_t)gyroConfig()->imuf_roll_lpf_cutoff_hz;
+        data->param5 = ( (uint16_t)gyroConfig()->imuf_pitch_lpf_cutoff_hz << 16) | (uint16_t)gyroConfig()->imuf_yaw_lpf_cutoff_hz;
+        data->param6 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
+        data->param7 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
+        data->param8 = ( (int16_t)boardAlignment()->rollDegrees << 16 )          | imufGyroAlignment();
+        data->param9 = ( (int16_t)boardAlignment()->yawDegrees << 16 )           | (int16_t)boardAlignment()->pitchDegrees;
+    }
+}
+
 void imufSpiGyroInit(gyroDev_t *gyro)
 {
     uint32_t attempt = 0;
@@ -284,14 +311,8 @@ void imufSpiGyroInit(gyroDev_t *gyro)
     imufCommand_t rxData;
 
     rxData.param1 = VerifyAllowedCommMode(gyroConfig()->imuf_mode);
-    rxData.param2 = ( (uint16_t)(gyroConfig()->imuf_rate+1) << 16)              | (uint16_t)gyroConfig()->imuf_w;
-    rxData.param3 = ( (uint16_t)gyroConfig()->imuf_roll_q << 16)              | (uint16_t)gyroConfig()->imuf_pitch_q;
-    rxData.param4 = ( (uint16_t)gyroConfig()->imuf_yaw_q << 16)               | (uint16_t)gyroConfig()->imuf_roll_lpf_cutoff_hz;
-    rxData.param5 = ( (uint16_t)gyroConfig()->imuf_pitch_lpf_cutoff_hz << 16) | (uint16_t)gyroConfig()->imuf_yaw_lpf_cutoff_hz;
-    rxData.param6 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
-    rxData.param7 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
-    rxData.param8 = ( (int16_t)boardAlignment()->rollDegrees << 16 )          | imufGyroAlignment();
-    rxData.param9 = ( (int16_t)boardAlignment()->yawDegrees << 16 )           | (int16_t)boardAlignment()->pitchDegrees;
+
+    setupImufParams(&rxData);
 
     for (attempt = 0; attempt < 10; attempt++)
     {
@@ -349,3 +370,5 @@ void imufEndCalibration(void)
 {
     isImufCalibrating = IMUF_NOT_CALIBRATING; //reset by EXTI
 }
+
+#endif

--- a/src/main/drivers/accgyro/accgyro_imuf9001.h
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.h
@@ -44,7 +44,7 @@ void imufEndCalibration(void);
 #endif
 
 
-#define IMUF_FIRMWARE_VERSION  108
+#define IMUF_FIRMWARE_MIN_VERSION  106
 extern volatile uint16_t imufCurrentVersion;
 typedef struct imufVersion
 {   

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -242,12 +242,15 @@ void mpuGyroDmaSpiReadFinish(gyroDev_t * gyro)
     //spi rx dma callback
     #ifdef USE_GYRO_IMUF9001
     memcpy(&imufData, dmaRxBuffer, sizeof(imufData_t));
-    acc.accADC[X]    = imufData.accX * acc.dev.acc_1G;
-    acc.accADC[Y]    = imufData.accY * acc.dev.acc_1G;
-    acc.accADC[Z]    = imufData.accZ * acc.dev.acc_1G;
-    gyro->gyroADC[X] = imufData.gyroX;
-    gyro->gyroADC[Y] = imufData.gyroY;
-    gyro->gyroADC[Z] = imufData.gyroZ;
+    acc.dev.ADCRaw[X]    = (int16_t)(imufData.accX * acc.dev.acc_1G);
+    acc.dev.ADCRaw[Y]    = (int16_t)(imufData.accY * acc.dev.acc_1G);
+    acc.dev.ADCRaw[Z]    = (int16_t)(imufData.accZ * acc.dev.acc_1G);
+    gyro->gyroADC[X]     = imufData.gyroX;
+    gyro->gyroADC[Y]     = imufData.gyroY;
+    gyro->gyroADC[Z]     = imufData.gyroZ;
+    gyro->gyroADCRaw[X]  = (int16_t)(imufData.gyroX * 16.4f);
+    gyro->gyroADCRaw[Y]  = (int16_t)(imufData.gyroY * 16.4f);
+    gyro->gyroADCRaw[Z]  = (int16_t)(imufData.gyroZ * 16.4f);
     if (gyroConfig()->imuf_mode == GTBCM_GYRO_ACC_QUAT_FILTER_F) {
         imufQuat.w       = imufData.quaternionW;
         imufQuat.x       = imufData.quaternionX;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -47,9 +47,6 @@
 #include "sensors/compass.h"
 #include "sensors/gyro.h"
 #include "sensors/sensors.h"
-#ifdef USE_ACC_IMUF9001
-#include "drivers/accgyro/accgyro_imuf9001.h"
-#endif
 
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_MULTITHREAD)
 #include <stdio.h>
@@ -372,11 +369,6 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 //  printf("[imu]deltaT = %u, imuDeltaT = %u, currentTimeUs = %u, micros64_real = %lu\n", deltaT, imuDeltaT, currentTimeUs, micros64_real());
     deltaT = imuDeltaT;
 #endif
-    // get sensor data
-#ifdef USE_GYRO_IMUF9001
-    if (gyroConfig()->imuf_mode != GTBCM_GYRO_ACC_QUAT_FILTER_F)
-    {
-#endif
     quaternion vError = VECTOR_INITIALIZE;
     quaternion vGyroAverage;
     quaternion vAccAverage;
@@ -388,22 +380,6 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     }
     applySensorCorrection(&vError);
     imuMahonyAHRSupdate(deltaT * 1e-6f, &vGyroAverage, &vError);
-#ifdef USE_GYRO_IMUF9001
-    } else {
-        UNUSED(deltaT);
-        UNUSED(applyAccError);
-        UNUSED(imuMahonyAHRSupdate);
-        qAttitude.w = imufQuat.w;
-        qAttitude.x = imufQuat.x;
-        qAttitude.y = imufQuat.y;
-        qAttitude.z = imufQuat.z;
-        quaternionNormalize(&qAttitude);
-        quaternionComputeProducts(&qAttitude, &qpAttitude);
-
-        DEBUG_SET(DEBUG_IMU, DEBUG_IMU0, lrintf(quaternionModulus(&qAttitude) * 1000));
-        DEBUG_SET(DEBUG_IMU, DEBUG_IMU1, lrintf(vGyroStdDevModulus * 1000));
-    }
-#endif
     imuUpdateEulerAngles();
 #endif
 

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -474,7 +474,6 @@ void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims)
 {
     UNUSED(currentTimeUs);
 
-    #ifndef USE_ACC_IMUF9001
     if (!acc.dev.readFn(&acc.dev)) {
         return;
     }
@@ -482,6 +481,7 @@ void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims)
         DEBUG_SET(DEBUG_ACCELEROMETER, axis, acc.dev.ADCRaw[axis]);
         acc.accADC[axis] = acc.dev.ADCRaw[axis];
     }
+    #ifndef USE_ACC_IMUF9001
     alignSensors(acc.accADC, acc.dev.accAlign);
     #endif
 
@@ -501,17 +501,10 @@ void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims)
     acc.accADC[Y] -= accelerationTrims->raw[Y];
     acc.accADC[Z] -= accelerationTrims->raw[Z];
 
-    #ifdef USE_GYRO_IMUF9001
-    if (gyroConfig()->imuf_mode != GTBCM_GYRO_ACC_QUAT_FILTER_F)
-    {
-    #endif
     ++accumulatedMeasurementCount;
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         accumulatedMeasurements[axis] += acc.accADC[axis];
     }
-    #ifdef USE_GYRO_IMUF9001
-    }
-    #endif
     acc.isAccelUpdatedAtLeastOnce = true;
 }
 

--- a/src/main/target/HELIOSPRING/target.h
+++ b/src/main/target/HELIOSPRING/target.h
@@ -198,7 +198,7 @@
 #define IMUF_DEFAULT_ROLL_Q   3000
 #define IMUF_DEFAULT_YAW_Q    3000
 #define IMUF_DEFAULT_W        32
-#define IMUF_DEFAULT_LPF_HZ   120.0f
+#define IMUF_DEFAULT_LPF_HZ   80.0f
 
 #define USE_BUTTERED_PIDS true
 


### PR DESCRIPTION
* makes our driver backwards compatible with caprica.
* fixes acc drift 
* removes using the quaternion from imuf because of integration with GPS/MAG/
* fixes intermittent gyro calibration problems due to the stdev check not getting properly scaled gyro data.
* sets default imuf LPF to 80 to help with people who have noisier resonance on quads.