### PR TITLE
adding starbuck settings

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -418,6 +418,9 @@ static uint16_t gyroConfig_imuf_w;
 static uint16_t gyroConfig_imuf_pitch_lpf_cutoff_hz;
 static uint16_t gyroConfig_imuf_roll_lpf_cutoff_hz;
 static uint16_t gyroConfig_imuf_yaw_lpf_cutoff_hz;
+static uint8_t gyroConfig_imuf_roll_af;
+static uint8_t gyroConfig_imuf_pitch_af;
+static uint8_t gyroConfig_imuf_yaw_af;
 #endif
 
 #if defined(USE_GYRO_IMUF9001)
@@ -430,7 +433,10 @@ static long cmsx_menuImuf_onEnter(void)
     gyroConfig_imuf_pitch_lpf_cutoff_hz = gyroConfig()->imuf_pitch_lpf_cutoff_hz;
     gyroConfig_imuf_roll_lpf_cutoff_hz = gyroConfig()->imuf_roll_lpf_cutoff_hz;
     gyroConfig_imuf_yaw_lpf_cutoff_hz = gyroConfig()->imuf_yaw_lpf_cutoff_hz;
-
+    gyroConfig_imuf_roll_af = gyroConfigMutable()->imuf_roll_af;
+    gyroConfig_imuf_pitch_af = gyroConfigMutable()->imuf_pitch_af;
+    gyroConfig_imuf_yaw_af = gyroConfigMutable()->imuf_yaw_af;
+    
     return 0;
 }
 #endif
@@ -444,9 +450,12 @@ static long cmsx_menuImuf_onExit(const OSD_Entry *self)
     gyroConfigMutable()->imuf_pitch_q = gyroConfig_imuf_pitch_q;
     gyroConfigMutable()->imuf_yaw_q = gyroConfig_imuf_yaw_q;
     gyroConfigMutable()->imuf_w = gyroConfig_imuf_w;
-    gyroConfigMutable()->imuf_pitch_lpf_cutoff_hz = gyroConfig_imuf_pitch_lpf_cutoff_hz;
     gyroConfigMutable()->imuf_roll_lpf_cutoff_hz = gyroConfig_imuf_roll_lpf_cutoff_hz;
+    gyroConfigMutable()->imuf_pitch_lpf_cutoff_hz = gyroConfig_imuf_pitch_lpf_cutoff_hz;
     gyroConfigMutable()->imuf_yaw_lpf_cutoff_hz = gyroConfig_imuf_yaw_lpf_cutoff_hz;
+    gyroConfigMutable()->imuf_roll_af = gyroConfig_imuf_roll_af;
+    gyroConfigMutable()->imuf_pitch_af = gyroConfig_imuf_pitch_af;
+    gyroConfigMutable()->imuf_yaw_af = gyroConfig_imuf_yaw_af;
 
     return 0;
 }
@@ -464,8 +473,10 @@ static OSD_Entry cmsx_menuImufEntries[] =
     { "ROLL LPF",  OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_imuf_roll_lpf_cutoff_hz,  0, 450,    1 }, 0 },
     { "PITCH LPF", OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_imuf_pitch_lpf_cutoff_hz, 0, 450,    1 }, 0 },
     { "YAW LPF",   OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_imuf_yaw_lpf_cutoff_hz,   0, 450,    1 }, 0 },
-
-
+    { "ROLL AF",   OME_TAB,    NULL, &(OSD_TAB_t)    { &gyroConfig_imuf_roll_af,             0, cms_offOnLabels}, 0 },
+    { "PITCH AF",  OME_TAB,    NULL, &(OSD_TAB_t)    { &gyroConfig_imuf_pitch_af,            0, cms_offOnLabels}, 0 },
+    { "YAW AF",    OME_TAB,    NULL, &(OSD_TAB_t)    { &gyroConfig_imuf_yaw_af,              0, cms_offOnLabels}, 0 },
+    
     { "BACK",        OME_Back,            NULL,   NULL,             0},
     { "SAVE&REBOOT", OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT_SAVEREBOOT, 0},
     { NULL, OME_END, NULL, NULL, 0 }

--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -574,7 +574,9 @@ void setupImufParams(imufCommand_t * data)
         data->param3 = ( (uint16_t)gyroConfig()->imuf_roll_q << 16)              | (uint16_t)gyroConfig()->imuf_pitch_q;
         data->param4 = ( (uint16_t)gyroConfig()->imuf_yaw_q << 16)               | (uint16_t)gyroConfig()->imuf_roll_lpf_cutoff_hz;
         data->param5 = ( (uint16_t)gyroConfig()->imuf_pitch_lpf_cutoff_hz << 16) | (uint16_t)gyroConfig()->imuf_yaw_lpf_cutoff_hz;
-        data->param6 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
+        data->param6 = ( (uint32_t)((gyroConfig()->imuf_roll_af & 1) | 
+                                    (gyroConfig()->imuf_pitch_af & 1) << 1 | 
+                                    (gyroConfig()->imuf_yaw_af & 1) << 2 ));
         data->param7 = ( (uint16_t)0 << 16)                                      | (uint16_t)0;
         data->param8 = ( (int16_t)boardAlignment()->rollDegrees << 16 )          | imufGyroAlignment();
         data->param9 = ( (int16_t)boardAlignment()->yawDegrees << 16 )           | (int16_t)boardAlignment()->pitchDegrees;

--- a/src/main/drivers/accgyro/accgyro_imuf9001.h
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.h
@@ -42,6 +42,15 @@ void imufEndCalibration(void);
 #ifndef IMUF_IMUF_W
 #define IMUF_IMUF_W  32
 #endif
+#ifndef IMUF_DEFAULT_ROLL_AF
+#define IMUF_DEFAULT_ROLL_AF  0
+#endif
+#ifndef IMUF_DEFAULT_PITCH_AF
+#define IMUF_DEFAULT_PITCH_AF  0
+#endif
+#ifndef IMUF_DEFAULT_YAW_AF
+#define IMUF_DEFAULT_YAW_AF  0
+#endif
 
 
 #define IMUF_FIRMWARE_MIN_VERSION  106

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -521,6 +521,9 @@ const clivalue_t valueTable[] = {
     { "imuf_pitch_lpf_cutoff_hz",   VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 450   }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_pitch_lpf_cutoff_hz) },
     { "imuf_roll_lpf_cutoff_hz",    VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 450   }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_roll_lpf_cutoff_hz) },
     { "imuf_yaw_lpf_cutoff_hz",     VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 450   }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_yaw_lpf_cutoff_hz) },
+    { "imuf_pitch_af",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_pitch_af) },
+    { "imuf_roll_af",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_roll_af) },
+    { "imuf_yaw_af",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_yaw_af) },
 #else
     { "gyro_filter_q",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_q) },
     { "gyro_filter_r",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_r) },

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -230,6 +230,9 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .imuf_roll_lpf_cutoff_hz = IMUF_DEFAULT_LPF_HZ,
     .imuf_pitch_lpf_cutoff_hz = IMUF_DEFAULT_LPF_HZ,
     .imuf_yaw_lpf_cutoff_hz = IMUF_DEFAULT_LPF_HZ,
+    .imuf_roll_af = IMUF_DEFAULT_ROLL_AF,
+    .imuf_pitch_af = IMUF_DEFAULT_PITCH_AF,
+    .imuf_yaw_af = IMUF_DEFAULT_YAW_AF,
     .gyro_offset_yaw = 0,
 );
 #else //USE_GYRO_IMUF9001

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -121,6 +121,9 @@ typedef struct gyroConfig_s {
     uint16_t imuf_pitch_lpf_cutoff_hz;
     uint16_t imuf_roll_lpf_cutoff_hz;
     uint16_t imuf_yaw_lpf_cutoff_hz;
+    uint8_t  imuf_pitch_af;
+    uint8_t  imuf_roll_af;
+    uint8_t  imuf_yaw_af;
 #else
     uint16_t gyro_filter_q;
     uint16_t gyro_filter_r;


### PR DESCRIPTION
added settings for starbuck 1.1.0 imuf.

The settings enable a more aggressive filtering scheme to tackle frame resonance. They can be turned on per-axis in case you have a problematic axis (such as roll) that is the result resonating frequencies. it is off by default.

to turn it on, just use the setting that corresponds to the appropriate problematic axis.
```
set imuf_pitch_af = ON
set imuf_roll_af = ON
set imuf_yaw_af = ON
```