### PR TITLE
deactivate slack hook (master)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,11 @@ cache:
   - downloads
   - tools
 
-notifications:
-  slack: betaflightgroup:LQSj02nsBEdefcO5UQcLgB0U
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/0c20f7a1a7e311499a88
-    on_success: always  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: always     # options: [always|never|change] default: always
+#notifications:
+#  slack: betaflightgroup:LQSj02nsBEdefcO5UQcLgB0U
+#  webhooks:
+#    urls:
+#      - https://webhooks.gitter.im/e/0c20f7a1a7e311499a88
+#    on_success: always  # options: [always|never|change] default: always
+#    on_failure: always  # options: [always|never|change] default: always
+#    on_start: always     # options: [always|never|change] default: always


### PR DESCRIPTION
During rebase you guys seem to have forgotten to deactivate the slack hook of betaflight. This fixes that.